### PR TITLE
Feature/mvp6：イベント参加起動、プロフィール詳細画面、参加イベント画面

### DIFF
--- a/src/components/blocks/DeleteDialog.tsx
+++ b/src/components/blocks/DeleteDialog.tsx
@@ -1,0 +1,54 @@
+import React, { memo } from 'react';
+import { Button, Text } from '@chakra-ui/react';
+import {
+  DialogActionTrigger,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { SecondaryButton } from '@/components/atoms/SecondaryButton';
+
+type Props = {
+  openConfirm: boolean;
+  setOpenConfirm: (open: boolean) => void;
+  loadingDelete: boolean;
+  onClickDelete: () => void;
+};
+
+export const DeleteDialog: React.FC<Props> = memo((props) => {
+  const { openConfirm, setOpenConfirm, loadingDelete, onClickDelete } = props;
+  return (
+    <DialogRoot
+      role="alertdialog"
+      lazyMount
+      open={openConfirm}
+      onOpenChange={(e) => setOpenConfirm(e.open)}
+      motionPreset="slide-in-bottom"
+      trapFocus={false}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>削除の確認</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <Text>削除したデータは戻せません。削除してもよろしいですか？</Text>
+        </DialogBody>
+        <DialogFooter mb="2">
+          <DialogActionTrigger asChild>
+            <Button variant="outline" aria-label="Cancel delete">
+              キャンセル
+            </Button>
+          </DialogActionTrigger>
+          <SecondaryButton loading={loadingDelete} onClick={onClickDelete}>
+            削除
+          </SecondaryButton>
+        </DialogFooter>
+        <DialogCloseTrigger />
+      </DialogContent>
+    </DialogRoot>
+  );
+});

--- a/src/components/blocks/JoinDialog.tsx
+++ b/src/components/blocks/JoinDialog.tsx
@@ -10,17 +10,18 @@ import {
   DialogRoot,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { SecondaryButton } from '@/components/atoms/SecondaryButton';
+import { ActionButton } from '@/components/atoms/ActionButton';
 
 type Props = {
   openConfirm: boolean;
   setOpenConfirm: (open: boolean) => void;
   loading: boolean;
   onClick: () => void;
+  eventName: string | undefined;
 };
 
-export const DeleteDialog: React.FC<Props> = memo((props) => {
-  const { openConfirm, setOpenConfirm, loading, onClick } = props;
+export const JoinDialog: React.FC<Props> = memo((props) => {
+  const { openConfirm, setOpenConfirm, loading, onClick, eventName } = props;
   return (
     <DialogRoot
       role="alertdialog"
@@ -32,20 +33,20 @@ export const DeleteDialog: React.FC<Props> = memo((props) => {
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>削除の確認</DialogTitle>
+          <DialogTitle>参加の確認</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <Text>削除したデータは戻せません。削除してもよろしいですか？</Text>
+          <Text>「{eventName}」に参加します。よろしいですか？</Text>
         </DialogBody>
         <DialogFooter mb="2">
           <DialogActionTrigger asChild>
-            <Button variant="outline" aria-label="Cancel delete">
+            <Button variant="outline" aria-label="Cancel join">
               キャンセル
             </Button>
           </DialogActionTrigger>
-          <SecondaryButton loading={loading} onClick={onClick}>
-            削除
-          </SecondaryButton>
+          <ActionButton loading={loading} onClick={onClick}>
+            参加
+          </ActionButton>
         </DialogFooter>
         <DialogCloseTrigger />
       </DialogContent>

--- a/src/components/pages/EventShow.tsx
+++ b/src/components/pages/EventShow.tsx
@@ -129,7 +129,7 @@ export const EventShow: React.FC = memo(() => {
                           {event?.profiles?.map((profile) => (
                             <Link onClick={() => onClickShowProfile(profile.profile_id)} key={profile.profile_id}>
                               <Tooltip content={profile.user_name} ids={{ trigger: profile.profile_id }} openDelay={0} showArrow>
-                                <Avatar.Root size="sm" ids={{ root: profile.profile_id }}>
+                                <Avatar.Root size="xs" ids={{ root: profile.profile_id }}>
                                   {profile.avatar_url ? <Avatar.Image src={profile.avatar_url} /> : <Avatar.Image src={defaultAvatar} />}
                                 </Avatar.Root>
                               </Tooltip>

--- a/src/components/pages/EventShow.tsx
+++ b/src/components/pages/EventShow.tsx
@@ -1,19 +1,10 @@
 import React, { memo, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { Avatar, Button, Card, Center, Container, DataList, Heading, HStack, Link, Spinner, Stack, Tag, Text } from '@chakra-ui/react';
-import {
-  DialogActionTrigger,
-  DialogBody,
-  DialogCloseTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Avatar, Card, Center, Container, DataList, Heading, HStack, Link, Spinner, Stack, Tag, Text } from '@chakra-ui/react';
 import { Tooltip } from '@/components/ui/tooltip';
 import { PrimaryButton } from '@/components/atoms/PrimaryButton';
 import { SecondaryButton } from '@/components/atoms/SecondaryButton';
+import { DeleteDialog } from '@/components/blocks/DeleteDialog';
 import { EventDetail } from '@/domains/eventDetail';
 import { fetchEventDetail, deleteEvent } from '@/utils/supabaseFunctions';
 import { useMessage } from '@/hooks/useMessage';
@@ -175,35 +166,7 @@ export const EventShow: React.FC = memo(() => {
               </Card.Footer>
             </Card.Root>
           </Container>
-
-          <DialogRoot
-            role="alertdialog"
-            lazyMount
-            open={openConfirm}
-            onOpenChange={(e) => setOpenConfirm(e.open)}
-            motionPreset="slide-in-bottom"
-            trapFocus={false}
-          >
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>削除の確認</DialogTitle>
-              </DialogHeader>
-              <DialogBody>
-                <p>削除したデータは戻せません。削除してもよろしいですか？</p>
-              </DialogBody>
-              <DialogFooter mb="2">
-                <DialogActionTrigger asChild>
-                  <Button variant="outline" aria-label="Cancel delete">
-                    キャンセル
-                  </Button>
-                </DialogActionTrigger>
-                <SecondaryButton loading={loadingDelete} onClick={onClickDelete}>
-                  削除
-                </SecondaryButton>
-              </DialogFooter>
-              <DialogCloseTrigger />
-            </DialogContent>
-          </DialogRoot>
+          <DeleteDialog openConfirm={openConfirm} setOpenConfirm={setOpenConfirm} loadingDelete={loadingDelete} onClickDelete={onClickDelete} />
         </>
       )}
     </>

--- a/src/components/pages/JoinedEvents.tsx
+++ b/src/components/pages/JoinedEvents.tsx
@@ -1,5 +1,121 @@
-import React, { memo } from 'react';
+import React, { memo, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { Button, Center, Container, Heading, HStack, Spinner, Table, Tag, Text, Flex } from '@chakra-ui/react';
+import { FiFileText } from 'react-icons/fi';
+import { Event } from '@/domains/event';
+import { useMessage } from '@/hooks/useMessage';
+import { fetchJoinedEvents } from '@/utils/supabaseFunctions';
 
 export const JoinedEvents: React.FC = memo(() => {
-  return <p>JoinedEventsページです</p>;
+  const navigate = useNavigate();
+  const { user_id } = useParams();
+  const { showMessage } = useMessage();
+
+  const [loading, setLoading] = useState<boolean>(false);
+  const [joinedEvents, setJoinedEvents] = useState<Event[]>([]);
+
+  useEffect(() => {
+    if (!user_id) {
+      showMessage({ title: 'ユーザー情報の取得に失敗しました', type: 'error' });
+      return;
+    }
+
+    const fetchHostedEventsFromUserId = async () => {
+      try {
+        setLoading(true);
+
+        const data = await fetchJoinedEvents(user_id);
+
+        setJoinedEvents(data);
+      } catch (error) {
+        showMessage({ title: 'イベント情報の取得に失敗しました', type: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchHostedEventsFromUserId();
+  }, []);
+
+  const onClickShowEvent = (event_id: string) => {
+    navigate(`../${event_id}`);
+  };
+
+  return (
+    <>
+      {loading ? (
+        <Center h="100vh">
+          <Spinner />
+        </Center>
+      ) : (
+        <Container my={{ base: '5', sm: '10' }} centerContent>
+          <Flex direction="column" align="center">
+            <Heading textAlign="center" mb="4">
+              参加イベント
+            </Heading>
+            <Table.Root size={{ base: 'sm', md: 'md' }} variant="outline" minW={{ base: 'auto', xl: '6xl' }} my={{ base: 5, md: 6 }} showColumnBorder>
+              <Table.Header bg="primary">
+                <Table.Row>
+                  <Table.ColumnHeader color="bg.primary" textAlign="center" width="20%">
+                    イベント名
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="bg.primary" textAlign="center" width="30%">
+                    詳細
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="bg.primary" textAlign="center" width="15%">
+                    ジャンル
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="bg.primary" textAlign="center" width="15%">
+                    プレイスタイル
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="bg.primary" textAlign="center" width="10%">
+                    参加者数
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="bg.primary" textAlign="center" width="10%"></Table.ColumnHeader>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body bg="white">
+                {joinedEvents.map((joinedEvent) => (
+                  <Table.Row key={joinedEvent.event_id}>
+                    <Table.Cell textAlign="left">{joinedEvent.name}</Table.Cell>
+                    <Table.Cell textAlign="left">
+                      <Text lineClamp="1">{joinedEvent.detail}</Text>
+                    </Table.Cell>
+                    <Table.Cell textAlign="left">
+                      <HStack flexWrap="wrap">
+                        {joinedEvent.genres.map((genre) => (
+                          <Tag.Root key={genre.genre_id}>
+                            <Tag.Label>{genre.name}</Tag.Label>
+                          </Tag.Root>
+                        ))}
+                      </HStack>
+                    </Table.Cell>
+                    <Table.Cell textAlign="left">
+                      <HStack flexWrap="wrap">
+                        {joinedEvent.play_styles.map((play_style) => (
+                          <Tag.Root key={play_style.play_style_id}>
+                            <Tag.Label>{play_style.name}</Tag.Label>
+                          </Tag.Root>
+                        ))}
+                      </HStack>
+                    </Table.Cell>
+                    <Table.Cell textAlign="center">
+                      {joinedEvent.profiles[0].count} / {joinedEvent.max_user_num}
+                    </Table.Cell>
+                    <Table.Cell textAlign="end">
+                      <HStack justifyContent="right">
+                        <Button colorPalette="gray" variant="outline" onClick={() => onClickShowEvent(joinedEvent.event_id)}>
+                          <FiFileText />
+                        </Button>
+                      </HStack>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table.Root>
+          </Flex>
+        </Container>
+      )}
+    </>
+  );
 });

--- a/src/components/pages/ProfileShow.tsx
+++ b/src/components/pages/ProfileShow.tsx
@@ -1,12 +1,107 @@
-import React, { memo } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
+import { Avatar, Card, Center, Container, DataList, Heading, HStack, Spinner, Stack, Tag } from '@chakra-ui/react';
+import { Profile } from '@/domains/profile';
+import { fetchProfile } from '@/utils/supabaseFunctions';
+import { useMessage } from '@/hooks/useMessage';
+import defaultAvatar from '@/assets/defautAvatar.svg';
 
 export const ProfileShow: React.FC = memo(() => {
   const { user_id, profile_id } = useParams();
+  const { showMessage } = useMessage();
+
+  const [loading, setLoading] = useState<boolean>(false);
+  const [profile, setProfile] = useState<Profile>();
+
+  useEffect(() => {
+    if (!user_id) {
+      showMessage({ title: 'ユーザー情報の取得に失敗しました', type: 'error' });
+      return;
+    } else if (!profile_id) {
+      showMessage({ title: 'プロフィール情報の取得に失敗しました', type: 'error' });
+      return;
+    }
+
+    const fetchProfileFromProfileId = async () => {
+      try {
+        setLoading(true);
+
+        const data = await fetchProfile(profile_id);
+        console.log(data);
+
+        setProfile(data);
+      } catch (error) {
+        showMessage({ title: 'ユーザー情報の取得に失敗しました', type: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfileFromProfileId();
+  }, []);
 
   return (
-    <p>
-      `ProfileShowページです。user_id:{user_id}, profile_id:{profile_id}`
-    </p>
+    <>
+      {loading ? (
+        <Center h="100vh">
+          <Spinner />
+        </Center>
+      ) : (
+        <Container my={{ base: '5', sm: '10' }} centerContent>
+          <Card.Root w="100%">
+            <Card.Header>
+              <Heading textAlign="center">プロフィール詳細</Heading>
+            </Card.Header>
+            <Card.Body>
+              <Stack gap={{ base: '5', sm: '7' }}>
+                <DataList.Root orientation={{ sm: 'horizontal' }} variant={{ base: 'bold', sm: 'subtle' }}>
+                  <DataList.Item>
+                    <DataList.ItemLabel>プロフィール画像</DataList.ItemLabel>
+                    <DataList.ItemValue>
+                      <Avatar.Root size="2xl" mr="3">
+                        {profile?.avatar_url ? <Avatar.Image src={profile.avatar_url} /> : <Avatar.Image src={defaultAvatar} />}
+                      </Avatar.Root>
+                    </DataList.ItemValue>
+                  </DataList.Item>
+                  <DataList.Item pt="4">
+                    <DataList.ItemLabel>ユーザー名</DataList.ItemLabel>
+                    <DataList.ItemValue>{profile?.user_name}</DataList.ItemValue>
+                  </DataList.Item>
+                  <DataList.Item pt="4">
+                    <DataList.ItemLabel>自己紹介</DataList.ItemLabel>
+                    <DataList.ItemValue>{profile?.introduction}</DataList.ItemValue>
+                  </DataList.Item>
+                  <DataList.Item pt="4">
+                    <DataList.ItemLabel>好きなジャンル</DataList.ItemLabel>
+                    <DataList.ItemValue>
+                      <HStack flexWrap="wrap">
+                        {profile?.accounts?.genres?.map((genre) => (
+                          <Tag.Root key={genre.genre_id}>
+                            <Tag.Label>{genre.name}</Tag.Label>
+                          </Tag.Root>
+                        ))}
+                      </HStack>
+                    </DataList.ItemValue>
+                  </DataList.Item>
+                  <DataList.Item pt="4">
+                    <DataList.ItemLabel>プレイスタイル</DataList.ItemLabel>
+                    <DataList.ItemValue>
+                      <HStack flexWrap="wrap">
+                        {profile?.accounts?.play_styles?.map((play_style) => (
+                          <Tag.Root key={play_style.play_style_id}>
+                            <Tag.Label>{play_style.name}</Tag.Label>
+                          </Tag.Root>
+                        ))}
+                      </HStack>
+                    </DataList.ItemValue>
+                  </DataList.Item>
+                </DataList.Root>
+              </Stack>
+            </Card.Body>
+            <Card.Footer justifyContent="center"></Card.Footer>
+          </Card.Root>
+        </Container>
+      )}
+    </>
   );
 });

--- a/src/domains/profile.ts
+++ b/src/domains/profile.ts
@@ -1,9 +1,12 @@
+import { User } from '@/domains/user';
+
 export class Profile {
   constructor(
     public profile_id: string,
     public user_id: string,
     public user_name: string,
     public avatar_url?: string,
-    public introduction?: string
+    public introduction?: string,
+    public accounts?: User
   ) {}
 }

--- a/src/domains/profile.ts
+++ b/src/domains/profile.ts
@@ -1,6 +1,7 @@
 export class Profile {
   constructor(
     public profile_id: string,
+    public user_id: string,
     public user_name: string,
     public avatar_url?: string,
     public introduction?: string

--- a/src/domains/user.ts
+++ b/src/domains/user.ts
@@ -5,8 +5,8 @@ import { Profile } from '@/domains/profile';
 export class User {
   constructor(
     public user_id: string,
-    public profiles: Profile,
-    public genres?: Genre,
-    public play_styles?: PlayStyle
+    public profiles?: Profile,
+    public genres?: Genre[],
+    public play_styles?: PlayStyle[]
   ) {}
 }

--- a/src/utils/supabaseFunctions.ts
+++ b/src/utils/supabaseFunctions.ts
@@ -5,6 +5,7 @@ import { Event } from '@/domains/event';
 import { EventDetail } from '@/domains/eventDetail';
 import { Genre } from '@/domains/genre';
 import { PlayStyle } from '@/domains/playStyle';
+import { Profile } from '@/domains/profile';
 import { ProfileFormData } from '@/domains/profileFormData';
 import { RegisterFormData } from '@/domains/registerFormData';
 import { User } from '@/domains/user';
@@ -54,6 +55,22 @@ export const fetchUserDetail = async (user_id: string): Promise<User> => {
     .select('user_id, profiles(profile_id, user_name, avatar_url, introduction), genres(genre_id, name), play_styles(play_style_id, name)')
     .eq('user_id', user_id)
     .returns<User>()
+    .single();
+
+  if (error) {
+    console.log(error.message);
+    throw new Error(error.message);
+  }
+
+  return data;
+};
+
+export const fetchProfile = async (profile_id: string) => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('profile_id, user_name, avatar_url, introduction, accounts(genres(genre_id, name), play_styles(play_style_id, name))')
+    .eq('profile_id', profile_id)
+    .returns<Profile>()
     .single();
 
   if (error) {

--- a/src/utils/supabaseFunctions.ts
+++ b/src/utils/supabaseFunctions.ts
@@ -179,6 +179,23 @@ export const fetchHostedEvents = async (user_id: string): Promise<Event[]> => {
   return data;
 };
 
+export const fetchJoinedEvents = async (user_id: string): Promise<Event[]> => {
+  const { data, error } = await supabase
+    .from('events')
+    .select(
+      'event_id, name, max_user_num, detail, genres(genre_id, name), play_styles(play_style_id, name), profiles(count), event_users!inner(user_id)'
+    )
+    .eq('event_users.user_id', user_id)
+    .returns<Event[]>();
+
+  if (error) {
+    console.log(error.message);
+    throw new Error(error.message);
+  }
+
+  return data;
+};
+
 export const fetchEventDetail = async (event_id: string): Promise<EventDetail> => {
   const { data, error } = await supabase
     .from('events')

--- a/src/utils/supabaseFunctions.ts
+++ b/src/utils/supabaseFunctions.ts
@@ -166,7 +166,7 @@ export const fetchEventDetail = async (event_id: string): Promise<EventDetail> =
   const { data, error } = await supabase
     .from('events')
     .select(
-      'event_id, name, max_user_num, detail, created_by, genres(genre_id, name), play_styles(play_style_id, name), profiles(profile_id, user_name, avatar_url)'
+      'event_id, name, max_user_num, detail, created_by, genres(genre_id, name), play_styles(play_style_id, name), profiles(profile_id, user_id, user_name, avatar_url)'
     )
     .eq('event_id', event_id)
     .returns<EventDetail>()
@@ -182,6 +182,16 @@ export const fetchEventDetail = async (event_id: string): Promise<EventDetail> =
 
 export const deleteEvent = async (event_id: string): Promise<void> => {
   const { error } = await supabase.from('events').delete().eq('event_id', event_id);
+
+  if (error) {
+    console.log(error.message);
+    throw new Error(error.message);
+  }
+};
+
+export const joinEvent = async (event_id: string, user_id: string): Promise<void> => {
+  console.log(event_id, user_id);
+  const { error } = await supabase.from('event_users').insert({ event_id, user_id });
 
   if (error) {
     console.log(error.message);


### PR DESCRIPTION
ユーザーはイベントに参加することができる。
参加しているイベント情報や参加者の情報を閲覧することができる。

## TODO

- [x] イベント詳細画面を改修する
    - [x] 参加するボタンを表示する（ログインユーザーが主催ユーザーではない、かつイベントに未参加、かつイベントの募集人数 > 参加者数の場合）
    - [x] 参加するボタン押下時にアラートを表示させる
        - [x] アラートメッセージ：`「{イベント名}」に参加します。よろしいですか？`
    - [x] Supbaseにデータを登録することができる
        - [x] `event_users`テーブル
    - [x] 登録に成功したら参加イベント画面（`localhost:5173/:user_id/events/joined`）遷移する
- [x] プロフィール詳細画面を実装する
    - [x] タイトルをつける
    - [x] レイアウトを当てながらプロフィール画像、ユーザー名、自己紹介、好きなジャンル（複数選択）、プレイスタイル（複数選択）の表示欄を作る(見た目のみ)
        - [x] 評価の表示は別MVPで実装する
    - [x] `profiles`、`genres`、`play_styles`などからデータ取得し、各項目を表示する
    - [x] ChakraUIを使ってスタイルを整える
- [x] 参加イベント画面を実装する
    - [x] タイトルをつける
    - [x] `events`、`event_genres`、`event_play_styles`、`event_users`などからデータ取得し、一覧表示する
    - [x] 詳細ボタンを表示する（イベント詳細画面に遷移させる）
    - [x] ChakraUIを使ってスタイルを整える