### PR TITLE
Feature/mvp7：おすすめイベント機能の実装

### DIFF
--- a/src/components/blocks/UserCard.tsx
+++ b/src/components/blocks/UserCard.tsx
@@ -7,7 +7,7 @@ import defaultAvatar from '@/assets/defautAvatar.svg';
 type Props = {
   userId: string;
   avatarUrl: string | undefined;
-  userName: string;
+  userName: string | undefined;
 };
 
 export const UserCard: React.FC<Props> = memo((props) => {

--- a/src/components/pages/Mypage.tsx
+++ b/src/components/pages/Mypage.tsx
@@ -1,17 +1,22 @@
 import React, { memo, useEffect, useState } from 'react';
-import { useParams } from 'react-router';
-import { Center, Container, HStack, Spinner } from '@chakra-ui/react';
+import { useNavigate, useParams } from 'react-router';
+import { Button, Center, Container, Heading, HStack, Spinner, Stack, Table, Tag, Text } from '@chakra-ui/react';
+import { FiFileText } from 'react-icons/fi';
 import { UserCard } from '@/components/blocks/UserCard';
 import { fetchUser } from '@/utils/supabaseFunctions';
+import { Event } from '@/domains/event';
 import { User } from '@/domains/user';
 import { useMessage } from '@/hooks/useMessage';
+import { fetchRecommendedEvents } from '@/utils/supabaseFunctions';
 
 export const Mypage: React.FC = memo(() => {
+  const navigate = useNavigate();
   const { user_id } = useParams();
   const { showMessage } = useMessage();
 
   const [user, setUser] = useState<User>();
   const [loading, setLoading] = useState<boolean>(false);
+  const [events, setEvents] = useState<Event[]>([]);
 
   useEffect(() => {
     if (!user_id) {
@@ -23,8 +28,11 @@ export const Mypage: React.FC = memo(() => {
       try {
         setLoading(true);
 
-        const data = await fetchUser(user_id);
-        setUser(data);
+        const user_data = await fetchUser(user_id);
+        const event_data = await fetchRecommendedEvents(user_id);
+
+        setUser(user_data);
+        setEvents(event_data);
       } catch (error) {
         showMessage({ title: 'ユーザー情報の取得に失敗しました', type: 'error' });
       } finally {
@@ -35,6 +43,10 @@ export const Mypage: React.FC = memo(() => {
     fetchUserData();
   }, []);
 
+  const onClickShowEvent = (event_id: string) => {
+    navigate(`/${user_id}/events/${event_id}`);
+  };
+
   return (
     <>
       {loading ? (
@@ -44,8 +56,78 @@ export const Mypage: React.FC = memo(() => {
       ) : (
         <Container my={{ base: '4', sm: '10' }} textAlign="center">
           <HStack align="start">
-            {user && <UserCard userId={user.user_id} avatarUrl={user.profiles.avatar_url} userName={user.profiles.user_name} />}
-            {/* Todo:おすすめイベント */}
+            {user && <UserCard userId={user.user_id} avatarUrl={user.profiles?.avatar_url} userName={user.profiles?.user_name} />}
+            <Stack>
+              <Heading textAlign="center" mb="4">
+                おすすめイベント
+              </Heading>
+              <Table.Root
+                size={{ base: 'sm', md: 'md' }}
+                variant="outline"
+                minW={{ base: 'auto', xl: '6xl' }}
+                my={{ base: 5, md: 6 }}
+                showColumnBorder
+              >
+                <Table.Header bg="primary">
+                  <Table.Row>
+                    <Table.ColumnHeader color="bg.primary" textAlign="center" width="20%">
+                      イベント名
+                    </Table.ColumnHeader>
+                    <Table.ColumnHeader color="bg.primary" textAlign="center" width="30%">
+                      詳細
+                    </Table.ColumnHeader>
+                    <Table.ColumnHeader color="bg.primary" textAlign="center" width="15%">
+                      ジャンル
+                    </Table.ColumnHeader>
+                    <Table.ColumnHeader color="bg.primary" textAlign="center" width="15%">
+                      プレイスタイル
+                    </Table.ColumnHeader>
+                    <Table.ColumnHeader color="bg.primary" textAlign="center" width="10%">
+                      参加者数
+                    </Table.ColumnHeader>
+                    <Table.ColumnHeader color="bg.primary" textAlign="center" width="10%"></Table.ColumnHeader>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body bg="white">
+                  {events.map((event) => (
+                    <Table.Row key={event.event_id}>
+                      <Table.Cell textAlign="left">{event.name}</Table.Cell>
+                      <Table.Cell textAlign="left">
+                        <Text lineClamp="1">{event.detail}</Text>
+                      </Table.Cell>
+                      <Table.Cell textAlign="left">
+                        <HStack flexWrap="wrap">
+                          {event.genres.map((genre) => (
+                            <Tag.Root key={genre.genre_id}>
+                              <Tag.Label>{genre.name}</Tag.Label>
+                            </Tag.Root>
+                          ))}
+                        </HStack>
+                      </Table.Cell>
+                      <Table.Cell textAlign="left">
+                        <HStack flexWrap="wrap">
+                          {event.play_styles.map((play_style) => (
+                            <Tag.Root key={play_style.play_style_id}>
+                              <Tag.Label>{play_style.name}</Tag.Label>
+                            </Tag.Root>
+                          ))}
+                        </HStack>
+                      </Table.Cell>
+                      <Table.Cell textAlign="center">
+                        {event.profiles[0].count} / {event.max_user_num}
+                      </Table.Cell>
+                      <Table.Cell textAlign="end">
+                        <HStack justifyContent="center">
+                          <Button colorPalette="gray" variant="outline" onClick={() => onClickShowEvent(event.event_id)}>
+                            <FiFileText />
+                          </Button>
+                        </HStack>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            </Stack>
           </HStack>
         </Container>
       )}

--- a/src/components/pages/ProfileEdit.tsx
+++ b/src/components/pages/ProfileEdit.tsx
@@ -55,6 +55,11 @@ export const ProfileEdit: React.FC = memo(() => {
         const genres = await fetchGenres();
         const playStyles = await fetchPlayStyles();
 
+        if (!userDetail?.profiles) {
+          showMessage({ title: 'プロフィール情報の取得に失敗しました', type: 'error' });
+          return;
+        }
+
         // ユーザー情報をセット
         setUserDetail(userDetail);
         setAvatarUrl(userDetail?.profiles.avatar_url);
@@ -106,6 +111,11 @@ export const ProfileEdit: React.FC = memo(() => {
     const updateProfileFromFormData = async () => {
       try {
         setLoadingUpload(true);
+
+        if (!userDetail?.profiles) {
+          showMessage({ title: 'プロフィール情報の取得に失敗しました', type: 'error' });
+          return;
+        }
 
         data.avatar_url = userDetail?.profiles.avatar_url;
         if (newAvatar) {

--- a/src/utils/supabaseFunctions.ts
+++ b/src/utils/supabaseFunctions.ts
@@ -196,6 +196,19 @@ export const fetchJoinedEvents = async (user_id: string): Promise<Event[]> => {
   return data;
 };
 
+export const fetchRecommendedEvents = async (user_id: string): Promise<Event[]> => {
+  const { data, error } = await supabase.rpc('get_recommended_events', {
+    p_user_id: user_id,
+  });
+
+  if (error) {
+    console.log(error.message);
+    throw new Error(error.message);
+  }
+
+  return data;
+};
+
 export const fetchEventDetail = async (event_id: string): Promise<EventDetail> => {
   const { data, error } = await supabase
     .from('events')


### PR DESCRIPTION
ユーザーはおすすめイベントを見ることができる

## TODO

- [x] マイページにおすすめイベントを実装する
    - [x] タイトルをつける
    - [x] `events`、`event_genres`、`event_play_styles`、`event_users`などからデータ取得し、一覧表示する
        - [x] おすすめイベントについて、簡易版としてプロフィールで登録した`好きなジャンル`または`プレイスタイル`が一致するイベントを表示するようにする
        - [x] ただし、自分が主催または参加しているイベント、募集人数と参加人数が一致しているイベントは、おすすめイベントに表示されないようにすること
    - [x] 詳細ボタンを表示する（イベント詳細画面に遷移させる）
    - [x] ChakraUIを使ってスタイルを整える